### PR TITLE
体育館毎に予約対象のみを通知するように修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "selenium-webdriver", "~>3.142.7"
 gem "json", "~>2.5.1"
 gem "hashie", "~>4.1.0"
 gem "line_notify", "~>1.0.1"
+gem "holiday_jp"
 
 group :development do
   gem "ruby-debug-ide", "~>0.7.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ GEM
       debase-ruby_core_source (>= 0.10.2)
     debase-ruby_core_source (0.10.12)
     hashie (4.1.0)
+    holiday_jp (0.8.0)
     json (2.5.1)
     line_notify (1.0.1)
     rake (13.0.6)
@@ -23,6 +24,7 @@ PLATFORMS
 DEPENDENCIES
   debase (~> 0.2.4.1)
   hashie (~> 4.1.0)
+  holiday_jp
   json (~> 2.5.1)
   line_notify (~> 1.0.1)
   ruby-debug-ide (~> 0.7.2)

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ $ bundle exec ruby script.rb
 # 環境変数を実行時に指定する場合
 $ HEADLESS_ON=false LINE_NOTIFY_TOKEN='xxxx' KAWASAKI_USER_ID='yyyy' KAWASAKI_USER_PASS='zzzzz' bundle exec ruby script.rb
 ```
+
+## Setting
+- [common.yml](./config/common.yml) 体育館の空き状況確認の共通設定
+  - check_month: 何ヶ月分チェックするかを数値で指定  ※当月含む
+- [kawasaki.yml](./config/kawasaki.yml) 川崎の体育館の設定
+  - gym.all_day: ここに記載した体育館は平日の夜間と土日祝日の全日程を通知対象とする
+  - gym.day_off: ここに記載した体育館は土日祝日の全日程を通知対象とする

--- a/lib/client/kawasaki.rb
+++ b/lib/client/kawasaki.rb
@@ -1,5 +1,6 @@
 require 'date'
 
+require './lib/util/day_util'
 require './lib/util/output'
 require './lib/util/notify'
 require './lib/pages/kawasaki/login'
@@ -27,10 +28,10 @@ module Lib
 
           # ファイル出力
           Util::Output.json_file( "kawasaki", kawasaki_gyms )
-          # LINE 通知
-          notify = Util::Notify.new
-          message = notify.create_notify_message( "川崎", kawasaki_gyms )
-          notify.send_line( @config.line_notify_token, message )
+          #体育館毎に予約対象の日付と時間帯のみ選別
+          checked_kawasaki_gyms = check_gym_type( kawasaki_gyms )
+          # LINE 通知　※通知対象がなければ通知しない
+          Util::Notify.send_line( @config.line_notify_token, "川崎", checked_kawasaki_gyms ) unless checked_kawasaki_gyms.nil?
         end
         puts "#---------------------"
       end
@@ -133,6 +134,37 @@ module Lib
           next_page = next_page.click_all_link
         end
         next_page
+      end
+
+      # 体育館毎タイプから休日 or 平日など通知する日程を選択
+      def check_gym_type( gym_available_list )
+        checked_gyms = []
+        gym_available_list['gyms'].each do |gym|
+          # 体育館毎の処理
+          checked_floors = []
+          gym['floors'].each do |floor|
+            # 体育館のフロア毎の処理
+            checked_availables = []
+            floor['availables'].each do |available|
+              # 空き日程の通知対象かをチェック
+              day = available['day']
+              if Util::DayUtil.check_jp_holiday_and_day_off( day )
+                # 土日祝日　※全日程が通知対象
+                checked_availables.push( {"day" => day, "classes" => available['classes']} )
+              else
+                # 平日　※夜間のみ通知対象
+                if @config.gym.all_day.include?( gym['name'] ) && available['classes'].include?( '夜間' )
+                  checked_availables.push( {"day" => day, "classes"=>[ "夜間"]} )
+                end
+              end
+            end
+            checked_floors.push( {"name" => floor['name'], "availables" => checked_availables} ) unless checked_availables.empty?
+          end
+          checked_gyms.push( {"name" => gym["name"], "floors" => checked_floors } ) unless checked_floors.empty?
+        end
+
+        # 通知対象が存在しなければ nil
+        { "gyms"=> checked_gyms } unless checked_gyms.empty?
       end
 
       # driver を破棄

--- a/lib/util/day_util.rb
+++ b/lib/util/day_util.rb
@@ -1,0 +1,30 @@
+require 'date'
+require 'holiday_jp'
+
+module Lib
+  module Util
+    class DayUtil
+
+      # 土日祝日を判定
+      def self.check_jp_holiday_and_day_off( day )
+        date = Date.strptime( day, '%Y-%m-%d' )
+        [ 0, 6 ].include?( date.wday ) or HolidayJp.holiday?( date )
+      end
+
+      # 曜日を返却 ※祝日の場合は '祝' を付加
+      def self.get_day_of_week( day )
+        day_of_week = [ "日", "月", "火", "水", "木", "金", "土" ]
+
+        date = Date.strptime( day, '%Y-%m-%d' )
+        result = day_of_week[ date.wday ]
+        if HolidayJp.holiday?( date )
+          "#{day_of_week[ date.wday ]}・祝"
+        else
+          day_of_week[ date.wday ]
+        end
+      end
+
+    end # DayUtil
+  end # Util
+end # Lib
+

--- a/lib/util/notify.rb
+++ b/lib/util/notify.rb
@@ -2,21 +2,23 @@ require 'json'
 require "date"
 require 'line_notify'
 
+require './lib/util/day_util'
+
 module Lib
   module Util
     class Notify
 
-      DAY_OF_WEEK = [ "日", "月", "火", "水", "木", "金", "土" ]
-
-      # 指定したtoken を利用して message を LINE Notify で送る
-      def send_line( token, message )
+      # 指定したtoken を利用して hash_obj を通知用の形にして LINE Notify で送る
+      # area は川崎、横浜、三田といったGエリアを指定
+      def self.send_line( token, area, hash_obj )
+        message = create_notify_message( area, hash_obj )
         line_notify = LineNotify.new( token )
         options = { message: message }
         line_notify.ping( options )
       end
       
       # hash 形式のデータから送信用のメッセージ作成
-      def create_notify_message( area, hash_obj )
+      def self.create_notify_message( area, hash_obj )
         message = "\n" + area + "\n"
 
         hash_obj['gyms'].each do |gym|
@@ -24,17 +26,11 @@ module Lib
           gym['floors'].each do |floor|
             message += "-- " + floor['name'] + "\n"
             floor['availables'].each do |available|
-              message += "  | " + available['day'] + " (" + get_day_of_week( available['day'] ) + ") : " + available['classes'].join( ',' ) + "\n"
+              message += "  | " + available['day'] + " (" + DayUtil.get_day_of_week( available['day'] ) + ") : " + available['classes'].join( ',' ) + "\n"
             end
           end
         end
         message
-      end
-
-      # 曜日を返却
-      def get_day_of_week( day )
-        date = Date.strptime( day, '%Y-%m-%d' )
-        DAY_OF_WEEK[date.wday]
       end
 
     end # Notify


### PR DESCRIPTION
### 概要

- 体育館の空きを全日程で確認した後に体育館毎に通知対象を以下に絞る
  - 平日の夜間、土日祝日の全日程を通知対象とする体育館
    - https://github.com/hisa9chi/gymnasium-availability-notice/blob/main/config/kawasaki.yml#L10-L13
  - 土日祝日の全日程を通知対象とする体育館
    - https://github.com/hisa9chi/gymnasium-availability-notice/blob/main/config/kawasaki.yml#L15-L21

### 補足
- 検出した体育館の空き全日程は./result 以下にファイルに書き出し保存